### PR TITLE
Add management command to compute friend suggestions for all users

### DIFF
--- a/backend/EduLite/users/management/commands/compute_friend_suggestions.py
+++ b/backend/EduLite/users/management/commands/compute_friend_suggestions.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
 from EduLite.users.models import User
-from EduLite.users.services.friend_suggestions import compute_friend_suggestions_for_user
+from EduLite.users.logic.friend_suggestions import (
+    compute_friend_suggestions_for_user,
+)
 
 class Command(BaseCommand):
     help = "Compute friend suggestions for all users"


### PR DESCRIPTION
## Summary
- add management command `compute_friend_suggestions` to recompute friend recommendations for every user

## Testing
- `python manage.py test users.tests.functions.test_friend_suggestions -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b0302bf03c83218d594a4a60b0bc47