### PR TITLE
Add friend suggestion API endpoint

### DIFF
--- a/backend/EduLite/users/tests/views/test_FriendSuggestionListView.py
+++ b/backend/EduLite/users/tests/views/test_FriendSuggestionListView.py
@@ -1,0 +1,52 @@
+from django.urls import reverse
+from rest_framework import status
+
+from .. import UsersAppTestCase
+from ...models import FriendSuggestion
+
+
+class FriendSuggestionListViewTest(UsersAppTestCase):
+    """Tests for the FriendSuggestionListView API endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse("friend-suggestion-list")
+
+        # Create friend suggestions for Ahmad
+        FriendSuggestion.objects.create(
+            user=self.ahmad,
+            suggested_user=self.miguel,
+            score=0.9,
+            reason="3 mutual friends",
+        )
+        FriendSuggestion.objects.create(
+            user=self.ahmad,
+            suggested_user=self.fatima,
+            score=0.5,
+            reason="Same course",
+        )
+
+    def test_requires_authentication(self):
+        """Endpoint should require authentication."""
+        response = self.client.get(self.url)
+        self.assert_response_success(response, status.HTTP_401_UNAUTHORIZED)
+
+    def test_returns_suggestions_ordered_by_score(self):
+        """Suggestions are returned ordered by descending score."""
+        self.authenticate_as(self.ahmad)
+        response = self.client.get(self.url)
+        self.assert_response_success(response, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 2)
+        scores = [s["score"] for s in response.data]
+        self.assertGreaterEqual(scores[0], scores[1])
+        self.assertEqual(response.data[0]["suggested_user"]["id"], self.miguel.id)
+
+    def test_filter_by_reason(self):
+        """Can filter suggestions by reason case-insensitively."""
+        self.authenticate_as(self.ahmad)
+        response = self.client.get(self.url, {"type": "3 MUTUAL FRIENDS"})
+        self.assert_response_success(response, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["suggested_user"]["id"], self.miguel.id)

--- a/backend/EduLite/users/urls.py
+++ b/backend/EduLite/users/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
         name="user-update",
     ),
     path("users/search/", views.UserSearchView.as_view(), name="user-search"),
+    path("users/friend-suggestions/", views.FriendSuggestionListView.as_view(), name="friend-suggestion-list"),
     # User Registration URL
     path("register/", views.UserRegistrationView.as_view(), name="user-register"),
     # Group URLs


### PR DESCRIPTION
## Summary
- add FriendSuggestionSerializer to expose suggested user details
- implement FriendSuggestionListView and route for logged-in users
- test friend suggestion endpoint and filtering

## Testing
- `python manage.py test users.tests.views.test_FriendSuggestionListView -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bacd9430f48321860ee55982f3127e